### PR TITLE
Add an option to pass --no-ext-diff to git

### DIFF
--- a/src/whole-diff-provider.ts
+++ b/src/whole-diff-provider.ts
@@ -59,6 +59,10 @@ function extractDiffArgs(uri: vscode.Uri): string[] {
     opts.push('-b');
   }
 
+  if (vscode.workspace.getConfiguration('diffEditor').get('ignoreExternalDiff') === true) {
+    opts.push('--no-ext-diff');
+  }
+
   // order is important here;
   const retval =
     extractStagedDiff(diffType, opts) ??


### PR DESCRIPTION
This allows the configuration option `git config diff.external` to be ignored, if it's using an incompatible program / producing an unexpected format.

I did this on my phone, hopefully I didn't screw it up. 😅

Fixes #4.